### PR TITLE
Enabling Specific Versions of Stable Release

### DIFF
--- a/claw_test.rb
+++ b/claw_test.rb
@@ -62,4 +62,23 @@ class ClawTest < Test::Unit::TestCase
 
     assert_equal 412, last_response.status
   end
+
+  def test_stable_will_redirect_to_correct_version_when_passed
+    release = STABLE_RELEASE_TO_FILENAME.keys.first
+    STABLE_VERSIONS.each do |version|
+      get 'stable', {'release' => release, 'version' => version}
+
+      redirect_link = STABLE_LINK % {version: version, release: STABLE_RELEASE_TO_FILENAME[release]}
+      assert_equal 302, last_response.status, "Error requesting: #{release}"
+      assert_equal redirect_link, last_response.original_headers['location'], "Could not find: #{release}"
+    end
+  end
+
+  def test_stable_will_error_when_passed_invalid_version
+    version = 'potato'
+    release = STABLE_RELEASE_TO_FILENAME.keys.first
+    get 'stable', {'release' => release, 'version' => version}
+
+    assert_equal 412, last_response.status
+  end
 end


### PR DESCRIPTION
Cleanup + Enabling the download of a specific version of a stable release. If no `version` param is passed, the `LATEST_STABLE_VERSION` is selected.

Note about `STABLE_VERSIONS`: Version `6.0.1` was not listed because artifacts generated in this version do not align with those generated in later versions. In order to reduce the complexity of error handling, this version was skipped.
