### PR TITLE
Update Gemfile.lock to reflect we're using Ruby 3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
CLAW was originally updated to use 3.3 which worked, but the max our CI tooling can currently easily support is 3.2. I'm not sure what actually uses `RUBY VERSION` in the `Gemfile.lock` (if anyone knows I'm definitely curious), but this should be done for the sake of correctness.

This was missed in the original PR (https://github.com/cloudfoundry/CLAW/pull/78).