### PR TITLE
Fix name of CF app from "claw-test" to "claw"

### DIFF
--- a/manifest-oss.yml
+++ b/manifest-oss.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: claw-test
+- name: claw
   buildpack: ruby_buildpack
   instances: 2
   env:


### PR DESCRIPTION
Renames the app name, which was incorrectly set to `claw-test`. (This is the first time this publishing workflow has been run on the `master` branch so maybe this shouldn't be surprising.)